### PR TITLE
Fix code scanning alert no. 1: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/api/IsbnApiResponseMapper.java
+++ b/src/main/java/api/IsbnApiResponseMapper.java
@@ -37,6 +37,9 @@ class IsbnApiResponseMapper {
     private static Document parseXmlToDocument(String response) throws ParserConfigurationException, IOException, SAXException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(false);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         DocumentBuilder builder = factory.newDocumentBuilder();
 
         return builder.parse(new InputSource(new StringReader(response)));


### PR DESCRIPTION
Fixes [https://github.com/radosnystudent/BookApp/security/code-scanning/1](https://github.com/radosnystudent/BookApp/security/code-scanning/1)

To fix the problem, we need to configure the `DocumentBuilderFactory` to disable DTDs and external entities. This can be done by setting specific features on the `DocumentBuilderFactory` instance. The best way to fix the problem without changing existing functionality is to add these configurations in the `parseXmlToDocument` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
